### PR TITLE
Use monospace font for preview

### DIFF
--- a/index.html
+++ b/index.html
@@ -378,8 +378,7 @@
         
         #textarea {
             font-family: 'Roboto Mono', monospace;
-            font-size: 1rem;
-            line-height: 1.2rem;
+            line-height: 1.6rem;
         }
     </style>
 

--- a/index.html
+++ b/index.html
@@ -375,9 +375,15 @@
             background-clip: padding-box;
             border-width: 0 0 0 4px;
         }
+        
+        #textarea {
+            font-family: 'Roboto Mono', monospace;
+            font-size: 1rem;
+            line-height: 1.2rem;
+        }
     </style>
 
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500">
+    <link rel="stylesheet" href="https://fonts.google.com/specimen/Roboto+Mono?selection.family=Roboto+Mono|Roboto:300,400,500">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/normalize/8.0.1/normalize.min.css" integrity="sha256-l85OmPOjvil/SOvVt3HnSSjzF1TUMyT9eV0c2BzEGzU=" crossorigin="anonymous" />
 
 </head>

--- a/index.html
+++ b/index.html
@@ -383,7 +383,8 @@
         }
     </style>
 
-    <link rel="stylesheet" href="https://fonts.google.com/specimen/Roboto+Mono?selection.family=Roboto+Mono|Roboto:300,400,500">
+    <link rel="preconnect" href="https://fonts.gstatic.com" />
+    <link href="https://fonts.googleapis.com/css2?family=Roboto+Mono&family=Roboto:wght@300;400;500&display=swap" rel="stylesheet" />
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/normalize/8.0.1/normalize.min.css" integrity="sha256-l85OmPOjvil/SOvVt3HnSSjzF1TUMyT9eV0c2BzEGzU=" crossorigin="anonymous" />
 
 </head>

--- a/index.html
+++ b/index.html
@@ -384,7 +384,7 @@
     </style>
 
     <link rel="preconnect" href="https://fonts.gstatic.com" />
-    <link href="https://fonts.googleapis.com/css2?family=Roboto+Mono&family=Roboto:wght@300;400;500&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto+Mono&family=Roboto:wght@300;400;500&display=swap" />
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/normalize/8.0.1/normalize.min.css" integrity="sha256-l85OmPOjvil/SOvVt3HnSSjzF1TUMyT9eV0c2BzEGzU=" crossorigin="anonymous" />
 
 </head>


### PR DESCRIPTION
Make the generated `textarea` contents display in monospace font

This pull-request addresses reported issue #1 by making the following modifications:
* Add *Roboto Mono* to the list of Google Fonts imported
* Create a style for the `#textarea` element to use the *Roboto Mono* font, and fall back to `monospace` if unavailable.
* Enhance code legibility by updating the font size and line height for the textarea

